### PR TITLE
feat(tuple)!: add GMP_TUPLE_GET as replacement for deprecated GMP_GET_TUPLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ GMP_TUPLE_SKIP(2, (a, b, c, d, e))    // expands to: (c, d, e)
 GMP_TUPLE_APPEND((a, b, c), d)        // expands to: (a, b, c, d)
 GMP_TUPLE_PREPEND((b, c, d), a)       // expands to: (a, b, c, d)
 GMP_TUPLE_CONCAT((a, b), (c, d))      // expands to: (a, b, c, d)
-GMP_GET_TUPLE(1, (42, "hello", 3.14)) // expands to: "hello"
+GMP_TUPLE_GET(1, (42, "hello", 3.14)) // expands to: "hello"
 ```
 
 #### Advanced Features

--- a/docs/content/docs/macro-metaprogramming.md
+++ b/docs/content/docs/macro-metaprogramming.md
@@ -49,7 +49,7 @@ GMP_SIZE_OF_VAARGS(a, b, c)      // 3
 GMP_GET_N(1, a, b, c)            // b
 
 GMP_TUPLE_SIZE((x, y, z))        // 3
-GMP_GET_TUPLE(1, (x, y, z))      // y
+GMP_TUPLE_GET(1, (x, y, z))      // y
 GMP_TUPLE_APPEND((x, y), z)      // (x, y, z)
 GMP_TUPLE_TAKE(2, (x, y, z, w))  // (x, y)
 ```

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/macro-metaprogramming.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/macro-metaprogramming.md
@@ -49,7 +49,7 @@ GMP_SIZE_OF_VAARGS(a, b, c)      // 3
 GMP_GET_N(1, a, b, c)            // b
 
 GMP_TUPLE_SIZE((x, y, z))        // 3
-GMP_GET_TUPLE(1, (x, y, z))      // y
+GMP_TUPLE_GET(1, (x, y, z))      // y
 GMP_TUPLE_APPEND((x, y), z)      // (x, y, z)
 GMP_TUPLE_TAKE(2, (x, y, z, w))  // (x, y)
 ```

--- a/include/gmp/dp/object_factory.hpp
+++ b/include/gmp/dp/object_factory.hpp
@@ -150,14 +150,14 @@ private:
   std::map<std::string, std::function<AbstractProduct*(const ConstructorArgs&... args)>> map_;
 };
 
-#define _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct) GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_GET_TUPLE, ConcreteProduct)GMP_IF(GMP_IS_TUPLE(ConcreteProduct), (1, ConcreteProduct))
+#define _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct) GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_TUPLE_GET, ConcreteProduct)GMP_IF(GMP_IS_TUPLE(ConcreteProduct), (1, ConcreteProduct))
 #define _GMP_GET_CONSTRUCTOR_TYPES(ConstructorArgs) GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConstructorArgs), GMP_REMOVE_PARENS, ConstructorArgs)GMP_IF(GMP_IS_TUPLE(ConstructorArgs), (ConstructorArgs))
 #define GMP_FACTORY_REGISTER_WITH_ARGS(AbstractProduct, ConstructorArgs, ConcreteProduct) \
   static gmp::object_factory<AbstractProduct, _GMP_GET_CONSTRUCTOR_TYPES(ConstructorArgs)>::register_type<_GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct)> \
-        GMP_CONCATS(gmp_reg_, AbstractProduct, _, _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct))(GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_STRINGIFY(GMP_TUPLE_GET(0, ConcreteProduct)), GMP_STRINGIFY(ConcreteProduct)));
+        GMP_CONCAT(gmp_reg_, GMP_CONCAT(AbstractProduct, GMP_CONCAT(_, _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct))))(GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_STRINGIFY(GMP_TUPLE_GET(0, ConcreteProduct)), GMP_STRINGIFY(ConcreteProduct)));
 #define GMP_FACTORY_REGISTER_NO_ARGS(AbstractProduct, ConcreteProduct) \
     static gmp::object_factory<AbstractProduct>::register_type<_GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct)> \
-        GMP_CONCATS(gmp_reg_, AbstractProduct, _, _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct))(GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_STRINGIFY(GMP_TUPLE_GET(0, ConcreteProduct)), GMP_STRINGIFY(ConcreteProduct)));
+        GMP_CONCAT(gmp_reg_, GMP_CONCAT(AbstractProduct, GMP_CONCAT(_, _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct))))(GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_STRINGIFY(GMP_TUPLE_GET(0, ConcreteProduct)), GMP_STRINGIFY(ConcreteProduct)));
 
 /**
  * @def GMP_FACTORY_REGISTER(AbstractProduct, ConstructorArgs, ...)
@@ -182,7 +182,7 @@ private:
  * @endcode
  */
 #define GMP_FACTORY_REGISTER(AbstractProduct, ConstructorArgs, ...) \
-  _GMP_FACTORY_REGISTER_IMPL(AbstractProduct, ConstructorArgs, __VA_ARGS__)
+  GMP_EVAL( _GMP_FACTORY_REGISTER_IMPL(AbstractProduct, ConstructorArgs, __VA_ARGS__) )
 #define _GMP_FACTORY_REGISTER_IMPL(AbstractProduct, ConstructorArgs, ...) \
   _GMP_FACTORY_REGISTER_IMPL_COMPAT_MSVC(AbstractProduct, ConstructorArgs, GMP_IS_EMPTY(__VA_ARGS__), GMP_TUPLE_EMPTY(ConstructorArgs), __VA_ARGS__)
 #define _GMP_FACTORY_REGISTER_IMPL_COMPAT_MSVC(AbstractProduct, ConstructorArgs, _0, _1, ...) \

--- a/include/gmp/dp/object_factory.hpp
+++ b/include/gmp/dp/object_factory.hpp
@@ -154,10 +154,10 @@ private:
 #define _GMP_GET_CONSTRUCTOR_TYPES(ConstructorArgs) GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConstructorArgs), GMP_REMOVE_PARENS, ConstructorArgs)GMP_IF(GMP_IS_TUPLE(ConstructorArgs), (ConstructorArgs))
 #define GMP_FACTORY_REGISTER_WITH_ARGS(AbstractProduct, ConstructorArgs, ConcreteProduct) \
   static gmp::object_factory<AbstractProduct, _GMP_GET_CONSTRUCTOR_TYPES(ConstructorArgs)>::register_type<_GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct)> \
-        GMP_CONCATS(gmp_reg_, AbstractProduct, _, _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct))(GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_STRINGIFY(GMP_GET_TUPLE(0, ConcreteProduct)), GMP_STRINGIFY(ConcreteProduct)));
+        GMP_CONCATS(gmp_reg_, AbstractProduct, _, _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct))(GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_STRINGIFY(GMP_TUPLE_GET(0, ConcreteProduct)), GMP_STRINGIFY(ConcreteProduct)));
 #define GMP_FACTORY_REGISTER_NO_ARGS(AbstractProduct, ConcreteProduct) \
     static gmp::object_factory<AbstractProduct>::register_type<_GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct)> \
-        GMP_CONCATS(gmp_reg_, AbstractProduct, _, _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct))(GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_STRINGIFY(GMP_GET_TUPLE(0, ConcreteProduct)), GMP_STRINGIFY(ConcreteProduct)));
+        GMP_CONCATS(gmp_reg_, AbstractProduct, _, _GMP_GET_CONCRETE_PRODUCT_CLASS(ConcreteProduct))(GMP_IF_THEN_ELSE(GMP_IS_TUPLE(ConcreteProduct), GMP_STRINGIFY(GMP_TUPLE_GET(0, ConcreteProduct)), GMP_STRINGIFY(ConcreteProduct)));
 
 /**
  * @def GMP_FACTORY_REGISTER(AbstractProduct, ConstructorArgs, ...)

--- a/include/gmp/macro/macro.hpp
+++ b/include/gmp/macro/macro.hpp
@@ -974,8 +974,32 @@
  * 
  * @note The tuple must contain at least (idx + 1) elements.
  *       If idx is out of bounds, the behavior is undefined.
+ * 
+ * @deprecated This macro is deprecated and will be removed in version 0.4.0.
+ *             Use GMP_TUPLE_GET instead, which is available from version 0.3.1 onward.
  */
 #define GMP_GET_TUPLE(idx, tup) GMP_GET_N(idx, GMP_REMOVE_PARENS(tup))
+
+/**
+ * @brief Get the nth element from a tuple/parameter list
+ * 
+ * This macro extracts the element at the specified index from a parenthesized
+ * tuple or parameter list. It is the recommended replacement for the deprecated
+ * GMP_GET_TUPLE macro.
+ * 
+ * Example:
+ *   GMP_TUPLE_GET(0, (int, float, char))  // Expands to: int
+ *   GMP_TUPLE_GET(1, (42, "hello", 3.14)) // Expands to: "hello"
+ * 
+ * @param idx Zero-based index of the element to retrieve
+ * @param tup Parenthesized tuple containing the elements
+ * @hideinitializer
+ * @since 0.3.1
+ * 
+ * @note The tuple must contain at least (idx + 1) elements.
+ *       If idx is out of bounds, the behavior is undefined.
+ */
+#define GMP_TUPLE_GET(idx, tup) GMP_GET_N(idx, GMP_REMOVE_PARENS(tup))
 
 /**
  * @brief Tests whether a preprocessor argument is a non-empty tuple
@@ -1194,16 +1218,16 @@
 #define _GMP_TUPLE_SKIP_ERROR(count, tup, res) res
 #define _GMP_TUPLE_SKIP_IMPL(count, tup, res) GMP_OVERLOAD_INVOKE(_GMP_TUPLE_SKIP_WHEN, GMP_NOT(GMP_EQUAL_INT_INDEPENDENT(count, GMP_TUPLE_SIZE(tup))))(count, tup, res)
 #define _GMP_TUPLE_SKIP_WHEN_0(count, tup, res) res
-#define _GMP_TUPLE_SKIP_WHEN_1(count, tup, res) _GMP_TUPLE_SKIP_WHEN_1_COMPAT_MSVC(count, tup, GMP_TUPLE_APPEND(res, GMP_GET_TUPLE(count, tup)))
+#define _GMP_TUPLE_SKIP_WHEN_1(count, tup, res) _GMP_TUPLE_SKIP_WHEN_1_COMPAT_MSVC(count, tup, GMP_TUPLE_APPEND(res, GMP_TUPLE_GET(count, tup)))
 #define _GMP_TUPLE_SKIP_WHEN_1_COMPAT_MSVC(count, tup, res) GMP_DEFER(_GMP_TUPLE_SKIP_INDIRECT)()(GMP_INC(count), tup, res)
 #define _GMP_TUPLE_SKIP_INDIRECT() _GMP_TUPLE_SKIP_IMPL
 
 // #define GMP_TUPLE_SKIP(count, tup) GMP_IF_THEN_ELSE(GMP_GREATER_INT(count, GMP_TUPLE_SIZE(tup)), _GMP_TUPLE_SKIP_ERROR, _GMP_TUPLE_SKIP_IMPL)(count, tup)
 // #define _GMP_TUPLE_SKIP_ERROR(count, tup) ()
-// #define _GMP_TUPLE_SKIP_IMPL(count, tup) GMP_GET_TUPLE(2, GMP_WHILE(_GMP_TUPLE_SKIP_COND, _GMP_TUPLE_SKIP_OP, (count, tup, ())))
-// #define _GMP_TUPLE_SKIP_COND(args) GMP_NOT(GMP_EQUAL_INT_INDEPENDENT(GMP_GET_TUPLE(0, args), GMP_TUPLE_SIZE(GMP_GET_TUPLE(1, args))))
-// #define _GMP_TUPLE_SKIP_OP(args) _GMP_TUPLE_SKIP_OP_COMPAT_MSVC(args, GMP_TUPLE_APPEND(GMP_GET_TUPLE(2, args), GMP_GET_TUPLE(GMP_GET_TUPLE(0, args), GMP_GET_TUPLE(1, args))))
-// #define _GMP_TUPLE_SKIP_OP_COMPAT_MSVC(args, res) (GMP_INC(GMP_GET_TUPLE(0, args)), GMP_GET_TUPLE(1, args), res)
+// #define _GMP_TUPLE_SKIP_IMPL(count, tup) GMP_TUPLE_GET(2, GMP_WHILE(_GMP_TUPLE_SKIP_COND, _GMP_TUPLE_SKIP_OP, (count, tup, ())))
+// #define _GMP_TUPLE_SKIP_COND(args) GMP_NOT(GMP_EQUAL_INT_INDEPENDENT(GMP_TUPLE_GET(0, args), GMP_TUPLE_SIZE(GMP_TUPLE_GET(1, args))))
+// #define _GMP_TUPLE_SKIP_OP(args) _GMP_TUPLE_SKIP_OP_COMPAT_MSVC(args, GMP_TUPLE_APPEND(GMP_TUPLE_GET(2, args), GMP_TUPLE_GET(GMP_TUPLE_GET(0, args), GMP_TUPLE_GET(1, args))))
+// #define _GMP_TUPLE_SKIP_OP_COMPAT_MSVC(args, res) (GMP_INC(GMP_TUPLE_GET(0, args)), GMP_TUPLE_GET(1, args), res)
 
 /**
  * @def GMP_TUPLE_TAKE(count, tup)
@@ -1259,15 +1283,15 @@
 #define _GMP_TUPLE_TAKE_ERROR(count, tup, res) tup
 #define _GMP_TUPLE_TAKE_IMPL(count, tup, res) GMP_OVERLOAD_INVOKE(_GMP_TUPLE_TAKE_WHEN, GMP_BOOL(count))(count, tup, res)
 #define _GMP_TUPLE_TAKE_WHEN_0(count, tup, res) res
-#define _GMP_TUPLE_TAKE_WHEN_1(count, tup, res) _GMP_TUPLE_TAKE_WHEN_1_COMPAT_MSVC(count, tup, GMP_TUPLE_PREPEND(res, GMP_GET_TUPLE(GMP_DEC(count), tup)))
+#define _GMP_TUPLE_TAKE_WHEN_1(count, tup, res) _GMP_TUPLE_TAKE_WHEN_1_COMPAT_MSVC(count, tup, GMP_TUPLE_PREPEND(res, GMP_TUPLE_GET(GMP_DEC(count), tup)))
 #define _GMP_TUPLE_TAKE_WHEN_1_COMPAT_MSVC(count, tup, res) GMP_DEFER(_GMP_TUPLE_TAKE_INDIRECT)()(GMP_DEC(count), tup, res)
 #define _GMP_TUPLE_TAKE_INDIRECT() _GMP_TUPLE_TAKE_IMPL
 // #define GMP_TUPLE_TAKE(count, tup) GMP_IF_THEN_ELSE(GMP_GREATER_INT(count, GMP_TUPLE_SIZE(tup)), _GMP_TUPLE_TAKE_ERROR, _GMP_TUPLE_TAKE_IMPL)(count, tup)
 // #define _GMP_TUPLE_TAKE_ERROR(count, tup) tup
-// #define _GMP_TUPLE_TAKE_IMPL(count, tup) GMP_GET_TUPLE(2, GMP_WHILE(_GMP_TUPLE_TAKE_COND, _GMP_TUPLE_TAKE_OP, (count, tup, ())))
-// #define _GMP_TUPLE_TAKE_COND(args) GMP_NOT(GMP_EQUAL_INT_INDEPENDENT(GMP_GET_TUPLE(0, args), 0))
-// #define _GMP_TUPLE_TAKE_OP(args) _GMP_TUPLE_TAKE_OP_COMPAT_MSVC(args, GMP_TUPLE_PREPEND(GMP_GET_TUPLE(2, args), GMP_GET_TUPLE(GMP_DEC(GMP_GET_TUPLE(0, args)), GMP_GET_TUPLE(1, args))))
-// #define _GMP_TUPLE_TAKE_OP_COMPAT_MSVC(args, res) (GMP_DEC(GMP_GET_TUPLE(0, args)), GMP_GET_TUPLE(1, args), res)
+// #define _GMP_TUPLE_TAKE_IMPL(count, tup) GMP_TUPLE_GET(2, GMP_WHILE(_GMP_TUPLE_TAKE_COND, _GMP_TUPLE_TAKE_OP, (count, tup, ())))
+// #define _GMP_TUPLE_TAKE_COND(args) GMP_NOT(GMP_EQUAL_INT_INDEPENDENT(GMP_TUPLE_GET(0, args), 0))
+// #define _GMP_TUPLE_TAKE_OP(args) _GMP_TUPLE_TAKE_OP_COMPAT_MSVC(args, GMP_TUPLE_PREPEND(GMP_TUPLE_GET(2, args), GMP_TUPLE_GET(GMP_DEC(GMP_TUPLE_GET(0, args)), GMP_TUPLE_GET(1, args))))
+// #define _GMP_TUPLE_TAKE_OP_COMPAT_MSVC(args, res) (GMP_DEC(GMP_TUPLE_GET(0, args)), GMP_TUPLE_GET(1, args), res)
 
 /**
  * \def GMP_FOR_EACH(call, ...)
@@ -1870,8 +1894,8 @@
  * @hideinitializer
  */
 #define GMP_CMP(x, y) GMP_WHILE(_GMP_CMP_COND, _GMP_CMP_OP, (x, y))
-#define _GMP_CMP_COND(args) GMP_AND(GMP_BOOL(GMP_GET_TUPLE(0, args)), GMP_BOOL(GMP_GET_TUPLE(1, args)))
-#define _GMP_CMP_OP(args) (GMP_DEC(GMP_GET_TUPLE(0, args)), GMP_DEC(GMP_GET_TUPLE(1, args)))
+#define _GMP_CMP_COND(args) GMP_AND(GMP_BOOL(GMP_TUPLE_GET(0, args)), GMP_BOOL(GMP_TUPLE_GET(1, args)))
+#define _GMP_CMP_OP(args) (GMP_DEC(GMP_TUPLE_GET(0, args)), GMP_DEC(GMP_TUPLE_GET(1, args)))
 
 /**
  * \def GMP_INC(value)
@@ -3442,9 +3466,9 @@
  * @hideinitializer
  */
 #define GMP_ADD(a, b) _GMP_ADD_IMPL(GMP_MINMAX(a, b))
-#define _GMP_ADD_IMPL(pair) GMP_GET_TUPLE(1, GMP_WHILE(_GMP_ADD_IMPL_COND, _GMP_ADD_IMPL_OP, pair))
-#define _GMP_ADD_IMPL_COND(args) GMP_BOOL(GMP_GET_TUPLE(0, args))
-#define _GMP_ADD_IMPL_OP(args) (GMP_DEC(GMP_GET_TUPLE(0, args)), GMP_INC(GMP_GET_TUPLE(1, args)))
+#define _GMP_ADD_IMPL(pair) GMP_TUPLE_GET(1, GMP_WHILE(_GMP_ADD_IMPL_COND, _GMP_ADD_IMPL_OP, pair))
+#define _GMP_ADD_IMPL_COND(args) GMP_BOOL(GMP_TUPLE_GET(0, args))
+#define _GMP_ADD_IMPL_OP(args) (GMP_DEC(GMP_TUPLE_GET(0, args)), GMP_INC(GMP_TUPLE_GET(1, args)))
 
 /**
  * @def GMP_SUB(a, b)
@@ -3470,9 +3494,9 @@
  */
 #define GMP_SUB(a, b) _GMP_SUB(GMP_LESS_INT(a, b), a, b)
 #define _GMP_SUB(sym, a, b) GMP_CONCAT(_GMP_SUB_RESULT_, sym) (_GMP_SUB_IMPL(GMP_MINMAX(a, b)))
-#define _GMP_SUB_IMPL(pair) GMP_GET_TUPLE(1, GMP_WHILE(_GMP_SUB_IMPL_COND, _GMP_SUB_IMPL_OP, pair))
-#define _GMP_SUB_IMPL_COND(args) GMP_BOOL(GMP_GET_TUPLE(0, args))
-#define _GMP_SUB_IMPL_OP(args) (GMP_DEC(GMP_GET_TUPLE(0, args)), GMP_DEC(GMP_GET_TUPLE(1, args)))
+#define _GMP_SUB_IMPL(pair) GMP_TUPLE_GET(1, GMP_WHILE(_GMP_SUB_IMPL_COND, _GMP_SUB_IMPL_OP, pair))
+#define _GMP_SUB_IMPL_COND(args) GMP_BOOL(GMP_TUPLE_GET(0, args))
+#define _GMP_SUB_IMPL_OP(args) (GMP_DEC(GMP_TUPLE_GET(0, args)), GMP_DEC(GMP_TUPLE_GET(1, args)))
 #define _GMP_SUB_RESULT_0(res) res
 #define _GMP_SUB_RESULT_1(res) -res
 

--- a/include/gmp/meta/meta.hpp
+++ b/include/gmp/meta/meta.hpp
@@ -704,7 +704,7 @@ void for_each_member(T&& value, F&& func) noexcept {
 
 /** @cond INTERNAL */
 template<typename T, typename F>
-void for_each_member(T&& value, F&& func) noexcept {
+void for_each_member(T&&, F&&) noexcept {
     static_assert(std::is_aggregate_v<std::remove_cvref_t<T>>,
         "for_each_member() can only be used with aggregate types.");
 }

--- a/include/gmp/meta/named_operator.hpp
+++ b/include/gmp/meta/named_operator.hpp
@@ -106,13 +106,13 @@ constexpr decltype(auto) invoke_named_operator(value_holder<Lhs, Func>&& holder,
 #define GMP_DEFINE_NAMED_OPERATOR_PAIR(pair)                                       \
     template<typename Lhs, typename Func>                                           \
         requires std::movable<Func>                                                 \
-    constexpr auto operator GMP_GET_TUPLE(0, pair) (Lhs&& lhs, ::gmp::detail::value_holder<Func> holder) { \
+    constexpr auto operator GMP_TUPLE_GET(0, pair) (Lhs&& lhs, ::gmp::detail::value_holder<Func> holder) { \
         return ::gmp::detail::bind_named_operator(std::forward<Lhs>(lhs), std::move(holder)); \
     }                                                                               \
                                                                                     \
     template<typename Lhs, typename Func, typename Rhs>                             \
         requires std::invocable<Func&&, Lhs, Rhs&&>                                 \
-    constexpr decltype(auto) operator GMP_GET_TUPLE(1, pair) (                                         \
+    constexpr decltype(auto) operator GMP_TUPLE_GET(1, pair) (                                         \
         ::gmp::detail::value_holder<Lhs, Func>&& holder, Rhs&& rhs) {               \
         return ::gmp::detail::invoke_named_operator(std::move(holder), std::forward<Rhs>(rhs)); \
     }

--- a/tests/dp_test.cpp
+++ b/tests/dp_test.cpp
@@ -24,9 +24,7 @@ struct square : shape {
     const char* name() const override { return "square"; }
 };
 
-#define EMPTY_TUPLE ()
-
-GMP_FACTORY_REGISTER(shape, EMPTY_TUPLE, circle, square)
+GMP_FACTORY_REGISTER(shape, (), circle, square)
 using shape_factory = gmp::object_factory<shape>;
 
 int main() {

--- a/tests/dp_test.cpp
+++ b/tests/dp_test.cpp
@@ -24,7 +24,9 @@ struct square : shape {
     const char* name() const override { return "square"; }
 };
 
-GMP_FACTORY_REGISTER(shape, (), circle, square)
+#define EMPTY_TUPLE ()
+
+GMP_FACTORY_REGISTER(shape, EMPTY_TUPLE, circle, square)
 using shape_factory = gmp::object_factory<shape>;
 
 int main() {

--- a/tests/macro_test.cpp
+++ b/tests/macro_test.cpp
@@ -12,10 +12,10 @@
 // // Expands to: std::cout << 1 << " "; std::cout << 2 << " "; std::cout << 3 << " ";
 // GMP_FOR_EACH(PRINT, 1, 2, 3)
 
-// #define COND(args) GMP_BOOL(GMP_GET_TUPLE(0, args))
-// #define OP(args) (GMP_DEC(GMP_GET_TUPLE(0, args)), GMP_CONCAT(GMP_GET_TUPLE(0, args), GMP_GET_TUPLE(1, args)))
-// // #define OP(args) OP_COMPAT_MSVC(args, GMP_ADD(GMP_GET_TUPLE(0, args), GMP_GET_TUPLE(1, args))) // (GMP_DEC(GMP_GET_TUPLE(0, tup)), GMP_ADD(GMP_GET_TUPLE(0, tup), GMP_GET_TUPLE(1, tup)))
-// // #define OP_COMPAT_MSVC(args, res) (GMP_DEC(GMP_GET_TUPLE(0, args)), res)
+// #define COND(args) GMP_BOOL(GMP_TUPLE_GET(0, args))
+// #define OP(args) (GMP_DEC(GMP_TUPLE_GET(0, args)), GMP_CONCAT(GMP_TUPLE_GET(0, args), GMP_TUPLE_GET(1, args)))
+// // #define OP(args) OP_COMPAT_MSVC(args, GMP_ADD(GMP_TUPLE_GET(0, args), GMP_TUPLE_GET(1, args))) // (GMP_DEC(GMP_TUPLE_GET(0, tup)), GMP_ADD(GMP_TUPLE_GET(0, tup), GMP_TUPLE_GET(1, tup)))
+// // #define OP_COMPAT_MSVC(args, res) (GMP_DEC(GMP_TUPLE_GET(0, args)), res)
 
 // GMP_WHILE(COND, OP, (2, 0))
 


### PR DESCRIPTION
Rename GMP_GET_TUPLE to GMP_TUPLE_GET.

- Mark GMP_GET_TUPLE as deprecated (removal in v0.4.0)
- Add GMP_TUPLE_GET (available from v0.3.1)
- Both macros share same implementation

BREAKING CHANGE: GMP_GET_TUPLE is deprecated and will be removed in version 0.4.0. Use GMP_TUPLE_GET instead.

Migration: #define GMP_GET_TUPLE(idx, tup) GMP_TUPLE_GET(idx, tup)

Closes #11